### PR TITLE
main: add base code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Local dir and files
+build/
+.vscode/
+sdkconfig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
+project(barometr)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# barometr
+# barometr [![License: MIT](https://shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
+
+Domowy barometr z wykorzystaniem [ESP32](https://www.espressif.com/en/products/devkits/esp32-devkitc) i [BMP280](https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp280/).

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "main.c"
+                    INCLUDE_DIRS "")

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_spi_flash.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+#define CHIP_NAME "ESP32"
+#endif
+
+#ifdef CONFIG_IDF_TARGET_ESP32S2BETA
+#define CHIP_NAME "ESP32-S2 Beta"
+#endif
+
+void app_main(void)
+{
+	printf("Hello world!\n");
+
+	/* Print chip information */
+	esp_chip_info_t chip_info;
+	esp_chip_info(&chip_info);
+	printf("This is %s chip with %d CPU cores, WiFi%s%s, ",
+		CHIP_NAME,
+		chip_info.cores,
+		(chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "",
+		(chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
+
+	printf("silicon revision %d, ", chip_info.revision);
+
+	printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
+		(chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
+
+	for (int i = 10; i >= 0; i--) {
+		printf("Restarting in %d seconds...\n", i);
+		vTaskDelay(1000 / portTICK_PERIOD_MS);
+	}
+	printf("Restarting now.\n");
+	fflush(stdout);
+	esp_restart();
+}

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,0 +1,7 @@
+# Domyślna konfiguracja dla projektu
+
+# Espressif IoT Development Framework (ESP-IDF) Project Configuration
+CONFIG_IDF_CMAKE=y
+CONFIG_IDF_TARGET="esp32"
+CONFIG_IDF_TARGET_ESP32=y
+CONFIG_IDF_FIRMWARE_CHIP_ID=0x0000


### PR DESCRIPTION
Bazowy kod dla aplikacji. Umozliwia kompilacje i zaladowanie firmware'u.

NOTE: zmiana nazwy katalogu main wymaga dodatkowch akcji: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#renaming-main-component

Signed-off-by: Tomasz Leman <apacz87@gmail.com>